### PR TITLE
Add blocking to allow to get tokens

### DIFF
--- a/src/main/java/org/commonjava/service/metadata/handler/FileEventConsumer.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/FileEventConsumer.java
@@ -1,5 +1,6 @@
 package org.commonjava.service.metadata.handler;
 
+import io.smallrye.common.annotation.Blocking;
 import org.commonjava.event.file.FileEvent;
 import org.commonjava.event.file.FileEventType;
 import org.commonjava.service.metadata.model.StoreKey;
@@ -32,6 +33,7 @@ public class FileEventConsumer
      * this observes the channel of {@link FileEvent} for a pom file, which means maven-metadata.xml will be cleared
      * when a version (pom) is uploaded or removed.
      */
+    @Blocking
     @Incoming("file-event-in")
     public CompletionStage<Void> receive( Message<FileEvent> message ) {
 

--- a/src/main/java/org/commonjava/service/metadata/handler/PromoteEventConsumer.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/PromoteEventConsumer.java
@@ -1,5 +1,6 @@
 package org.commonjava.service.metadata.handler;
 
+import io.smallrye.common.annotation.Blocking;
 import org.commonjava.event.promote.PathsPromoteCompleteEvent;
 import org.commonjava.service.metadata.client.repository.ArtifactStore;
 import org.commonjava.service.metadata.client.repository.StoreListingDTO;
@@ -32,6 +33,7 @@ public class PromoteEventConsumer
     @Inject
     MetadataHandler metadataHandler;
 
+    @Blocking
     @Incoming("promote-event-in")
     public CompletionStage<Void> receive( Message<PathsPromoteCompleteEvent> message )
     {


### PR DESCRIPTION
There is `client.getTokens().await().indefinitely();` which includes the method `await()`, and that is not allowed in event-loop, adding annotation `blocking` to make it work and we may need to figure out the better way for this.  

Ref: https://github.com/quarkusio/quarkus/issues/13835