### PR TITLE
Fix the NPE when the token expired

### DIFF
--- a/src/main/java/org/commonjava/service/metadata/client/util/CustomClientRequestFilter.java
+++ b/src/main/java/org/commonjava/service/metadata/client/util/CustomClientRequestFilter.java
@@ -33,15 +33,10 @@ public class CustomClientRequestFilter implements ClientRequestFilter
     {
         if ( securityEnabled )
         {
-            if ( tokens == null )
+            if ( tokens == null || tokens.isAccessTokenExpired() )
             {
                 logger.debug("Security enabled, get oidc Tokens");
                 tokens = client.getTokens().await().indefinitely();
-            }
-            else if (tokens.isAccessTokenExpired())
-            {
-                logger.debug("Refresh oidc Tokens");
-                tokens = client.refreshTokens(tokens.getRefreshToken()).await().indefinitely();
             }
             requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.getAccessToken());
         }


### PR DESCRIPTION
There was error Refresh token is null during tests on devel instance which failed the builds always, based on the [doc](https://www.keycloak.org/docs/12.0/release_notes/#keycloak-12-0-0), Keycloak added support for disabling refresh tokens in the case of client_credentials grants, so to be safe, let's avoid to use refresh token to acquire access token.