### PR TITLE
Override org.wildfly.security:wildfly-elytron to fix critical vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,11 +218,11 @@
             <version>3.12.0</version>
         </dependency>
 
-        <!-- fix security vulnerabilities -->
+        <!-- Fix critical vulnerabilities https://nvd.nist.gov/vuln/detail/CVE-2022-45047-->
         <dependency>
-            <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-common</artifactId>
-            <version>2.9.2</version>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+            <version>1.20.4.Final</version>
         </dependency>
 
         <!-- for unit test -->


### PR DESCRIPTION
In previous pr, the 'sshd-common' being as an indirect dependency of ISPN does not fix the vulnerability. This pr updates the direct dependency of ISPN. It looks good when I check the dep tree on my local - the downstream dep sshd is updated to safe 2.9.2.