### PR TITLE
Update to use Quarkus 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.commonjava.indy.service</groupId>
     <artifactId>indy-metadata-service</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
 
     <name>Indy :: Service :: Metadata Service</name>
     <inceptionYear>2021</inceptionYear>
@@ -47,6 +47,7 @@
         <quarkus.package.type>uber-jar</quarkus.package.type>
         <httpcoreVersion>4.4.9</httpcoreVersion>
         <httpclientVersion>4.5.13</httpclientVersion>
+        <indysecurity.version>1.2-SNAPSHOT</indysecurity.version>
     </properties>
 
     <dependencies>
@@ -212,7 +213,7 @@
         <dependency>
             <groupId>org.commonjava.indy.service</groupId>
             <artifactId>indy-security</artifactId>
-            <version>1.0</version>
+            <version>${indysecurity.version}</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <httpcoreVersion>4.4.9</httpcoreVersion>
         <httpclientVersion>4.5.13</httpclientVersion>
         <indysecurity.version>1.2-SNAPSHOT</indysecurity.version>
+        <maven.repo.metadata.version>3.9.6</maven.repo.metadata.version>
     </properties>
 
     <dependencies>
@@ -170,12 +171,11 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-repository-metadata</artifactId>
-            <version>3.6.3</version>
+            <version>${maven.repo.metadata.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
         </dependency>
 
         <!-- for unit test -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.commonjava</groupId>
         <artifactId>service-parent</artifactId>
-        <version>4</version>
+        <version>5-SNAPSHOT</version>
     </parent>
 
     <groupId>org.commonjava.indy.service</groupId>
@@ -136,6 +136,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/java/org/commonjava/service/metadata/client/repository/RepositoryService.java
+++ b/src/main/java/org/commonjava/service/metadata/client/repository/RepositoryService.java
@@ -17,11 +17,11 @@ package org.commonjava.service.metadata.client.repository;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
 
 @Path("/api/admin/stores")
 @RegisterRestClient(configKey="repo-service-api")

--- a/src/main/java/org/commonjava/service/metadata/client/storage/StorageService.java
+++ b/src/main/java/org/commonjava/service/metadata/client/storage/StorageService.java
@@ -18,11 +18,11 @@ package org.commonjava.service.metadata.client.storage;
 import org.commonjava.event.storage.BatchCleanupRequest;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import javax.ws.rs.DELETE;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
 
 @Path("/api/storage")
 @RegisterRestClient(configKey="storage-service-api")

--- a/src/main/java/org/commonjava/service/metadata/client/util/CustomClientRequestFilter.java
+++ b/src/main/java/org/commonjava/service/metadata/client/util/CustomClientRequestFilter.java
@@ -21,13 +21,13 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Priority;
-import javax.inject.Inject;
-import javax.ws.rs.Priorities;
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.ext.Provider;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 @Priority(Priorities.AUTHENTICATION)

--- a/src/main/java/org/commonjava/service/metadata/controller/MetadataController.java
+++ b/src/main/java/org/commonjava/service/metadata/controller/MetadataController.java
@@ -21,8 +21,8 @@ import org.commonjava.service.metadata.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
 

--- a/src/main/java/org/commonjava/service/metadata/handler/FileEventConsumer.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/FileEventConsumer.java
@@ -24,8 +24,8 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.concurrent.CompletionStage;
 
 import static org.commonjava.service.metadata.handler.MetadataUtil.getMetadataPath;

--- a/src/main/java/org/commonjava/service/metadata/handler/MetadataHandler.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/MetadataHandler.java
@@ -28,10 +28,10 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
 import java.util.Set;
 

--- a/src/main/java/org/commonjava/service/metadata/handler/OtelAdapter.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/OtelAdapter.java
@@ -20,7 +20,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class OtelAdapter

--- a/src/main/java/org/commonjava/service/metadata/handler/PromoteEventConsumer.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/PromoteEventConsumer.java
@@ -25,8 +25,8 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;

--- a/src/main/java/org/commonjava/service/metadata/handler/SpecialPathManagerImpl.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/SpecialPathManagerImpl.java
@@ -21,9 +21,9 @@ import org.commonjava.indy.model.core.PathStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/src/main/java/org/commonjava/service/metadata/handler/Traced.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/Traced.java
@@ -15,7 +15,7 @@
  */
 package org.commonjava.service.metadata.handler;
 
-import javax.interceptor.InterceptorBinding;
+import jakarta.interceptor.InterceptorBinding;
 import java.lang.annotation.*;
 
 @InterceptorBinding

--- a/src/main/java/org/commonjava/service/metadata/handler/TracingInterceptor.java
+++ b/src/main/java/org/commonjava/service/metadata/handler/TracingInterceptor.java
@@ -21,11 +21,11 @@ import io.opentelemetry.context.Scope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Priority;
-import javax.inject.Inject;
-import javax.interceptor.AroundInvoke;
-import javax.interceptor.Interceptor;
-import javax.interceptor.InvocationContext;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
 
 @Traced
 @Priority(10)

--- a/src/main/java/org/commonjava/service/metadata/jaxrs/DTOStreamingOutPut.java
+++ b/src/main/java/org/commonjava/service/metadata/jaxrs/DTOStreamingOutPut.java
@@ -21,8 +21,8 @@ import org.apache.commons.io.output.CountingOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.io.OutputStream;
 

--- a/src/main/java/org/commonjava/service/metadata/jaxrs/MetadataResource.java
+++ b/src/main/java/org/commonjava/service/metadata/jaxrs/MetadataResource.java
@@ -20,18 +20,16 @@ import org.commonjava.service.metadata.controller.MetadataController;
 import org.commonjava.service.metadata.model.MetadataInfo;
 import org.commonjava.service.metadata.model.SpecialPathDTO;
 import org.commonjava.service.metadata.model.SpecialPathInfo;
-import org.commonjava.service.metadata.model.SpecialPathSet;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Response;
 
-import java.util.Collection;
 import java.util.Set;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.microprofile.openapi.annotations.enums.ParameterIn.PATH;
 
 @Path( "/api/metadata" )

--- a/src/main/java/org/commonjava/service/metadata/jaxrs/ResponseHelper.java
+++ b/src/main/java/org/commonjava/service/metadata/jaxrs/ResponseHelper.java
@@ -20,19 +20,19 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.Response.Status;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
 import java.util.function.Consumer;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @ApplicationScoped
 public class ResponseHelper

--- a/src/main/java/org/commonjava/service/metadata/model/IndyPathGenerator.java
+++ b/src/main/java/org/commonjava/service/metadata/model/IndyPathGenerator.java
@@ -17,10 +17,10 @@ package org.commonjava.service.metadata.model;
 
 import org.commonjava.indy.model.util.DefaultPathGenerator;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/main/java/org/commonjava/service/metadata/model/NPMStoragePathCalculator.java
+++ b/src/main/java/org/commonjava/service/metadata/model/NPMStoragePathCalculator.java
@@ -21,8 +21,8 @@ import org.commonjava.service.metadata.handler.SpecialPathManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 import static org.commonjava.service.metadata.handler.MetadataUtil.NPM_METADATA_NAME;
 import static org.commonjava.service.metadata.handler.PathUtils.normalize;

--- a/src/main/java/org/commonjava/service/metadata/stats/StatsHandler.java
+++ b/src/main/java/org/commonjava/service/metadata/stats/StatsHandler.java
@@ -20,13 +20,13 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path( "/api/stats" )
 public class StatsHandler

--- a/src/main/java/org/commonjava/service/metadata/stats/Versioning.java
+++ b/src/main/java/org/commonjava/service/metadata/stats/Versioning.java
@@ -18,8 +18,8 @@ package org.commonjava.service.metadata.stats;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.enterprise.inject.Alternative;
-import javax.inject.Named;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Named;
 
 @Alternative
 @Named

--- a/src/main/java/org/commonjava/service/metadata/stats/VersioningProvider.java
+++ b/src/main/java/org/commonjava/service/metadata/stats/VersioningProvider.java
@@ -18,9 +18,9 @@ package org.commonjava.service.metadata.stats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.inject.Default;
-import javax.inject.Singleton;
-import javax.ws.rs.Produces;
+import jakarta.enterprise.inject.Default;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.Produces;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,10 +69,10 @@ kafka:
         servers: "localhost:9092"
 
 storage-service-api/mp-rest/url: http://localhost
-storage-service-api/mp-rest/scope: javax.inject.Singleton
+storage-service-api/mp-rest/scope: jakarta.inject.Singleton
 
 repo-service-api/mp-rest/url: http://localhost
-repo-service-api/mp-rest/scope: javax.inject.Singleton
+repo-service-api/mp-rest/scope: jakarta.inject.Singleton
 
 indy_security:
     enabled: true
@@ -119,7 +119,7 @@ indy_security:
 
 
     storage-api/mp-rest/url: http://localhost
-    storage-api/mp-rest/scope: javax.inject.Singleton
+    storage-api/mp-rest/scope: jakarta.inject.Singleton
 
     indy_security:
         enabled: true

--- a/src/test/java/org/commonjava/service/metadata/client/RepositoryServiceTest.java
+++ b/src/test/java/org/commonjava/service/metadata/client/RepositoryServiceTest.java
@@ -23,8 +23,8 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 
 @QuarkusTest
 public class RepositoryServiceTest

--- a/src/test/java/org/commonjava/service/metadata/handler/MockableRepositoryService.java
+++ b/src/test/java/org/commonjava/service/metadata/handler/MockableRepositoryService.java
@@ -26,9 +26,9 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/test/java/org/commonjava/service/metadata/handler/MockableRepositoryService.java
+++ b/src/test/java/org/commonjava/service/metadata/handler/MockableRepositoryService.java
@@ -21,13 +21,11 @@ import org.commonjava.service.metadata.client.repository.ArtifactStore;
 import org.commonjava.service.metadata.client.repository.RepositoryService;
 import org.commonjava.service.metadata.client.repository.StoreListingDTO;
 import org.commonjava.service.metadata.model.StoreKey;
-import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -51,10 +51,10 @@ kafka:
         servers: "localhost:9092"
 
 pathmap-api/mp-rest/url: http://localhost
-pathmap-api/mp-rest/scope: javax.inject.Singleton
+pathmap-api/mp-rest/scope: jakarta.inject.Singleton
 
 repo-service-api/mp-rest/url: http://localhost
-repo-service-api/mp-rest/scope: javax.inject.Singleton
+repo-service-api/mp-rest/scope: jakarta.inject.Singleton
 
 "%dev":
     quarkus:


### PR DESCRIPTION
Update the namespace from javax.* to jakarta.* , aligning with Quarkus 3. 
Upgrade indy-security to the 1.2-SNAPSHOT
Bump the version to 2.0-SNAPSHOT, and keep 1.x with branch 1.x